### PR TITLE
Account for orientation of GD

### DIFF
--- a/R/Blink.LDRemove.R
+++ b/R/Blink.LDRemove.R
@@ -44,8 +44,13 @@
 #Authors: Yao Zhou
 #Last update: 08/15/2016
   GDneo = as.matrix(GDneo)
-  SNP.index = apply(GDneo,1,sd)!=0
-  GDneo = GDneo[SNP.index,]
+  if (orientation == "row") {
+    SNP.index = apply(GDneo,1,sd)!=0
+    GDneo = GDneo[SNP.index,]
+  } else {
+    SNP.index = apply(GDneo, 2, sd) != 0
+    GDneo = GDneo[, SNP.index]
+  }
   Porder = Porder[SNP.index]
   l = block
 	seqQTN=NULL


### PR DESCRIPTION
Master branch does not account for the orientation of GD when filtering out invariant potential pseudo-QTNs. The current code works when GD is in row orientation but not column orientation. When `length(Porder)` < `nrow(GDneo)` this adds a large number of NA's to the end of `SNP.index` and then to the end of `Porder`. This leads to `seq(bottom:up)` producing a sequence longer than the `ncol(GDneo)`. The proposed change accounts for different orientations of GD in the filtering of invariant pseudo-QTNs.